### PR TITLE
Update MainFrame.java

### DIFF
--- a/src/org/ash/gui/MainFrame.java
+++ b/src/org/ash/gui/MainFrame.java
@@ -366,7 +366,7 @@ public class MainFrame extends JFrame implements ActionListener{
 		} else if (versionOracleDB.startsWith("9.")) {
 			this.database = new ASHDatabasePG95(this.model);
 		} else {
-			this.database = new ASHDatabasePG95(this.model);
+			this.database = new ASHDatabasePG13(this.model);
 		}
 		
 		this.collectorUI = new CollectorUI(this.database, this.latency);


### PR DESCRIPTION
Replacing the deprecated pg 9 with new condition to allow pg14 and onward.  This change is needed because waiting column was removed from pg_stat_activity table and that was causing issues while trying to connect to pg14 database.